### PR TITLE
rework to 0xcxxx addresses

### DIFF
--- a/source/VidHD.h
+++ b/source/VidHD.h
@@ -36,14 +36,17 @@ public:
 	virtual void InitializeIO(LPBYTE pCxRomPeripheral);
 
 	static BYTE __stdcall IORead(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
+	static BYTE __stdcall C0Write(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 
 	void VideoIOWrite(WORD pc, WORD addr, BYTE bWrite, BYTE value, ULONG nExecutedCycles);
 
 	bool IsSHR(void) { return (m_NEWVIDEO & 0xC0) == 0xC0; }	// 11000000 = Enable SHR(b7) | Linearize SHR video memory(b6)
-	bool IsSDHR(void) { return (m_NEWVIDEO & 0x40) == 0x40; }   // override SHR(b4) for SDHR.  This is ugly but easy, fix if we get real support
+	bool IsSDHR(void);
+	void ControlSDHR(BYTE value);
 	bool IsDHGRBlackAndWhite(void) { return (m_NEWVIDEO & (1 << 5)) ? true : false; }
 	bool IsWriteAux(void);
 
+	void SDHRWriteByte(BYTE value);
 	void SDHRWritePixels(uint16_t vert, uint16_t horz, bgra_t* pVideoAddress);
 
 	static void UpdateSHRCell(bool is640Mode, bool isColorFillMode, uint16_t addrPalette, bgra_t* pVideoAddress, uint32_t a);

--- a/source/VidHDSdhr.h
+++ b/source/VidHDSdhr.h
@@ -6,9 +6,9 @@ class VidHDSdhr
 {
 public:
 	VidHDSdhr() {
-		shm_area = MemGetAuxPtr(0xc000);
-		bank = shm_area[0x7cff];
+		m_bEnabled = false;
 		error_flag = false;
+		memset(error_str, sizeof(error_str), 0);
 		memset(uploaded_data_region, sizeof(uploaded_data_region), 0);
 		memset(tileset_records, sizeof(tileset_records), 0);
 		memset(palette_records, sizeof(palette_records), 0);
@@ -37,7 +37,17 @@ public:
 		}
 
 	}
-	bool ProcessCommands();
+	void ToggleSDHR(bool value) {
+		m_bEnabled = value;
+	}
+
+	bool IsSdhrEnabled(void) {
+		return m_bEnabled;
+	}
+
+	void SDHRWriteByte(BYTE byte);
+
+	bool ProcessCommands(void);
 
 	bgra_t GetPixel(uint16_t vert, uint16_t horz);
 
@@ -54,6 +64,7 @@ public:
 		return true;
 	}
 private:
+	bool m_bEnabled;
 	struct TilesetRecord {
 		uint8_t depth;
 		uint64_t xdim;
@@ -86,12 +97,11 @@ private:
 		uint8_t* bitmask_tile_indexes = NULL;
 	};
 
-	static const uint16_t cmd_buffer_size = 15 * 1024;
 	static const uint16_t screen_xcount = 640;
 	static const uint16_t screen_ycount = 360;
-	BYTE* shm_area;
-	BYTE bank;
+	std::vector<uint8_t> command_buffer;
 	bool error_flag;
+	char error_str[256];
 	uint8_t uploaded_data_region[256 * 256 * 256];
 	TilesetRecord tileset_records[256];
 	PaletteRecord palette_records[256];


### PR DESCRIPTION
moving to 0xCxxx addresses.  No longer uses SHR memory, although you still need to activate SHR via writing 0xc1 to 0xc029 because I haven't worked through splitting it out fully in NTSC.cpp.  But once SHR is on, activate and manipulate SDHR with writing to 0xc0b0 and 0xc0b1:

0xC0B0 is control byte:
- write 0x00 to disable sdhr (if enabled), keeps internal state
- write 0x01 to enable sdhr (initializing if needed), keeps internal state
- write 0x02 to process queued commands
- write 0x03 to reset sdhr (destroys state, including error states)

0xC0B1 is data byte:
- write bytes to append to command buffer if sdhr is enabled, has no effect if disabled

UploadData command now can point to any starting page in main memory, and copies specified number of pages from there to the specified destination in the card's uploaded memory region.  